### PR TITLE
Generify the validateBuildscriptDepencies task type 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # ChangeLog
 
 ### v0.1.11-SNAPSHOT - unreleased
-
+ - Rename `GdmcValidateBuildscriptDepsTask` -> `GdmcValidateDepsTask` and take a collection of `Dependencies` as input.
 
 ### v0.1.10-SNAPSHOT - July 29th, 2018
->>>>>>> release/v0.1.10
  - Upgrade gradle 4.4 -> 4.9
  - Upgrade deployable 0.1.12 -> 0.2.0
  - remove support for old `maven` plugin

--- a/src/main/groovy/com/episode6/hackit/gdmc/exception/GdmcDependencyMismatchException.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/exception/GdmcDependencyMismatchException.groovy
@@ -4,20 +4,20 @@ import com.episode6.hackit.gdmc.data.GdmcDependency
 import org.gradle.api.GradleException
 
 /**
- * Exception thrown from the gdmcValidateBuildscriptDeps task when a buildscript dependency is found that
- * does not match its mapped dependency version in gdmc
+ * Exception thrown from the {@link com.episode6.hackit.gdmc.task.GdmcValidateDepsTask} task when a
+ * dependency is found that does not match its mapped dependency version in gdmc
  */
-class GdmcBuildscriptDependencyMismatchException extends GradleException {
+class GdmcDependencyMismatchException extends GradleException {
 
   private static String formatMessage(Map<GdmcDependency, String> errors) {
-    StringBuilder msg = new StringBuilder("Buildscript Dependency Mapping Errors: \n")
+    StringBuilder msg = new StringBuilder("Dependency Mapping Errors: \n")
     errors.each { GdmcDependency dep, String reason ->
       msg.append("Mismatched dependency: ").append(dep.fullMavenKey).append(", reason: ").append(reason).append("\n")
     }
     return msg.toString()
   }
 
-  GdmcBuildscriptDependencyMismatchException(Map<GdmcDependency, String> errors) {
+  GdmcDependencyMismatchException(Map<GdmcDependency, String> errors) {
     super(formatMessage(errors))
   }
 }

--- a/src/main/groovy/com/episode6/hackit/gdmc/plugin/GdmcTasksPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/plugin/GdmcTasksPlugin.groovy
@@ -2,7 +2,7 @@ package com.episode6.hackit.gdmc.plugin
 
 import com.episode6.hackit.gdmc.data.GdmcDependency
 import com.episode6.hackit.gdmc.task.GdmcResolveTask
-import com.episode6.hackit.gdmc.task.GdmcValidateBuildscriptDepsTask
+import com.episode6.hackit.gdmc.task.GdmcValidateDepsTask
 import com.episode6.hackit.gdmc.task.GdmcValidateSelfTask
 import com.episode6.hackit.gdmc.util.*
 import org.gradle.api.Action
@@ -160,7 +160,7 @@ class GdmcTasksPlugin implements Plugin<Project>, HasProjectTrait {
       group = VERIFICATION_TASK_GROUP
     }
 
-    project.task("gdmcValidateBuildscriptDeps", type: GdmcValidateBuildscriptDepsTask) {
+    project.task("gdmcValidateBuildscriptDeps", type: GdmcValidateDepsTask) {
       description = "Verifies that any buildscript dependencies that are mapped in gdmc have the correct mapped versions."
       group = VERIFICATION_TASK_GROUP
     }

--- a/src/main/groovy/com/episode6/hackit/gdmc/plugin/GdmcTasksPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/plugin/GdmcTasksPlugin.groovy
@@ -166,6 +166,8 @@ class GdmcTasksPlugin implements Plugin<Project>, HasProjectTrait {
       dependencies = {
         (project.buildscript.configurations + project.rootProject.buildscript.configurations).collectMany {it.dependencies}
       }
+      ignoreSnapshots = true
+      ignoreDynamicVersions = true
     }
 
     project.afterEvaluate {

--- a/src/main/groovy/com/episode6/hackit/gdmc/plugin/GdmcTasksPlugin.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/plugin/GdmcTasksPlugin.groovy
@@ -163,6 +163,9 @@ class GdmcTasksPlugin implements Plugin<Project>, HasProjectTrait {
     project.task("gdmcValidateBuildscriptDeps", type: GdmcValidateDepsTask) {
       description = "Verifies that any buildscript dependencies that are mapped in gdmc have the correct mapped versions."
       group = VERIFICATION_TASK_GROUP
+      dependencies = {
+        (project.buildscript.configurations + project.rootProject.buildscript.configurations).collectMany {it.dependencies}
+      }
     }
 
     project.afterEvaluate {

--- a/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
@@ -1,7 +1,7 @@
 package com.episode6.hackit.gdmc.task
 
 import com.episode6.hackit.gdmc.data.GdmcDependency
-import com.episode6.hackit.gdmc.exception.GdmcBuildscriptDependencyMismatchException
+import com.episode6.hackit.gdmc.exception.GdmcDependencyMismatchException
 import com.episode6.hackit.gdmc.util.HasProjectTrait
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.ExternalDependency
@@ -34,7 +34,7 @@ class GdmcValidateDepsTask extends DefaultTask implements VerificationTask, HasP
 
     try {
       performValidation()
-    } catch (GdmcBuildscriptDependencyMismatchException e) {
+    } catch (GdmcDependencyMismatchException e) {
       if (ignoreFailures) {
         GChop.e(e, "Buildscript Validation Failed")
       } else {
@@ -66,7 +66,7 @@ class GdmcValidateDepsTask extends DefaultTask implements VerificationTask, HasP
     }
 
     if (!errors.isEmpty()) {
-      throw new GdmcBuildscriptDependencyMismatchException(errors);
+      throw new GdmcDependencyMismatchException(errors);
     }
   }
 }

--- a/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
@@ -25,6 +25,10 @@ class GdmcValidateDepsTask extends DefaultTask implements VerificationTask, HasP
 
   @Input boolean ignoreFailures = false
 
+  @Input boolean ignoreSnapshots = false
+
+  @Input boolean ignoreDynamicVersions = false
+
   @Input Closure<Collection<Dependency>> dependencies
 
   @TaskAction
@@ -49,7 +53,9 @@ class GdmcValidateDepsTask extends DefaultTask implements VerificationTask, HasP
   private void performValidation() {
     Map<GdmcDependency, String> errors = new HashMap<>();
 
-        dependencies.call().findAll {it instanceof ExternalDependency && it.version != "+" && !it.version.contains("SNAPSHOT")}
+        dependencies.call().findAll {it instanceof ExternalDependency }
+        .findAll { !ignoreDynamicVersions || (!it.version.endsWith("+") && !it.version.endsWith("*")) }
+        .findAll { !ignoreSnapshots || !it.version.contains("SNAPSHOT") }
         .collect {GdmcDependency.from(it)}
         .each {
       List<GdmcDependency> mappedDeps = dependencyMap.lookupWithOverrides(it.mapKey)

--- a/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
@@ -18,7 +18,7 @@ import static com.episode6.hackit.gdmc.util.GdmcLogger.GChop
  * we validate that the versions match. While this isn't as nice as automatically mapping the versions
  * for you, it should help ensure your buildscript dependencies stay up to date when sharing a gdmc file.
  */
-class GdmcValidateBuildscriptDepsTask extends DefaultTask implements VerificationTask, HasProjectTrait {
+class GdmcValidateDepsTask extends DefaultTask implements VerificationTask, HasProjectTrait {
 
   @Input Closure<Boolean> required = {true}
 

--- a/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
+++ b/src/main/groovy/com/episode6/hackit/gdmc/task/GdmcValidateDepsTask.groovy
@@ -4,6 +4,7 @@ import com.episode6.hackit.gdmc.data.GdmcDependency
 import com.episode6.hackit.gdmc.exception.GdmcDependencyMismatchException
 import com.episode6.hackit.gdmc.util.HasProjectTrait
 import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -23,6 +24,8 @@ class GdmcValidateDepsTask extends DefaultTask implements VerificationTask, HasP
   @Input Closure<Boolean> required = {true}
 
   @Input boolean ignoreFailures = false
+
+  @Input Closure<Collection<Dependency>> dependencies
 
   @TaskAction
   def validate() {
@@ -46,9 +49,7 @@ class GdmcValidateDepsTask extends DefaultTask implements VerificationTask, HasP
   private void performValidation() {
     Map<GdmcDependency, String> errors = new HashMap<>();
 
-    (project.buildscript.configurations + project.rootProject.buildscript.configurations)
-        .collectMany {it.dependencies}
-        .findAll {it instanceof ExternalDependency && it.version != "+" && !it.version.contains("SNAPSHOT")}
+        dependencies.call().findAll {it instanceof ExternalDependency && it.version != "+" && !it.version.contains("SNAPSHOT")}
         .collect {GdmcDependency.from(it)}
         .each {
       List<GdmcDependency> mappedDeps = dependencyMap.lookupWithOverrides(it.mapKey)


### PR DESCRIPTION
Rename `GdmcValidateBuildscriptDepsTask` -> `GdmcValidateDepsTask` and take a collection of gradle `Dependencies` (not gdmc dependencies) as input. This will be used when we move the source-code to `buildSrc`, to validate our implementation dependencies (since we can't easily infer them from the gdmc json)