### PR TITLE
[LOGGING] Use gradle's sfl4j logger instead of stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v0.1.11-SNAPSHOT - unreleased
  - Rename `GdmcValidateBuildscriptDepsTask` -> `GdmcValidateDepsTask` and take a collection of `Dependencies` as input.
  - Upgrade gradle 4.9 -> 5.1.1
+ - Use slf4j under the hood for gdmc logging
 
 ### v0.1.10 - July 29th, 2018
  - Upgrade gradle 4.4 -> 4.9

--- a/buildSrc/src/main/groovy/com/episode6/hackit/gdmc/util/GdmcLogger.groovy
+++ b/buildSrc/src/main/groovy/com/episode6/hackit/gdmc/util/GdmcLogger.groovy
@@ -1,19 +1,20 @@
 package com.episode6.hackit.gdmc.util
 
+import com.episode6.hackit.chop.Chop
 import com.episode6.hackit.chop.Chop.ChoppingToolsAdapter
 import com.episode6.hackit.chop.Chop.Tree
 import com.episode6.hackit.chop.groovy.GroovyDebugTagger
-import com.episode6.hackit.chop.tree.StdOutDebugTree
+import com.episode6.hackit.chop.slf4j.Slf4jTree
 
 /**
  * Helper class to to turn on logging
  */
 class GdmcLogger {
-  static final ChoppingToolsAdapter GChop = com.episode6.hackit.chop.Chop.withTagger(new GroovyDebugTagger())
+  static final ChoppingToolsAdapter GChop = Chop.withTagger(new GroovyDebugTagger())
 
-  private static final Tree STD_OUT_TREE = new StdOutDebugTree()
+  private static final Tree TREE = Slf4jTree.create("gdmc")
 
   void enable() {
-    com.episode6.hackit.chop.Chop.plantTree(STD_OUT_TREE)
+    Chop.plantTree(TREE)
   }
 }

--- a/project-dependencies.gradle
+++ b/project-dependencies.gradle
@@ -2,4 +2,5 @@ def chopVersion = '0.1.10'
 dependencies {
   implementation "com.episode6.hackit.chop:chop-core:$chopVersion"
   implementation "com.episode6.hackit.chop:chop-groovy:$chopVersion"
+  implementation "com.episode6.hackit.chop:chop-slf4j:$chopVersion"
 }


### PR DESCRIPTION
Update gdmc's logging to use Slf4j, making the logs more gradle-friendly.